### PR TITLE
Add shell application to listen measurements

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -219,11 +219,11 @@
         "poetry2nix": "poetry2nix_2"
       },
       "locked": {
-        "lastModified": 1716321052,
-        "narHash": "sha256-g3uDRcEWunaED8bEsUETB0aMWghO7EtZC/7a9A1Z9HE=",
+        "lastModified": 1723014348,
+        "narHash": "sha256-QugnVACg0iUuji0RAHi/Uxf+wcT9pJT+xpmrO/ESJjo=",
         "owner": "SEGuRo-Projekt",
         "repo": "Platform",
-        "rev": "af98a35576b2512582a4020f8bcc46dd21c470cb",
+        "rev": "fae95e65d721a43777b6a5279a975954a04edb76",
         "type": "github"
       },
       "original": {

--- a/nix/nixosModules/gateway/default.nix
+++ b/nix/nixosModules/gateway/default.nix
@@ -123,7 +123,6 @@ in
       tpm2-tools
       villas-generate-gateway-config
       listenMeasurements
-      parseTopic
     ];
 
     services.villas.node = {

--- a/nix/nixosModules/gateway/default.nix
+++ b/nix/nixosModules/gateway/default.nix
@@ -22,6 +22,33 @@ let
       villas-generate-gateway-config < ${cfg.gatewayConfigPath} > ${cfg.villasConfigPath}
     '';
   };
+
+  parseTopic = pkgs.writeShellApplication {
+    name = "parse-topic";
+    runtimeInputs = with pkgs; [ jq ];
+    text = ''
+      jq -r '.[]
+      | try to_entries[]
+      | select(.key | try startswith("mqtt"))
+      | .value.out.publish' ${cfg.villasConfigPath}
+    '';
+
+  };
+
+  listenMeasurements = pkgs.writeShellApplication {
+    name = "listen-measurements";
+    runtimeInputs = with pkgs; [ parseTopic ];
+    text = ''
+      protobuf-subscriber \
+      --host ${cfg.mqtt.host} \
+      --port ${toString cfg.mqtt.port} \
+      --cafile ${cfg.tls.caCert} \
+      --cert ${cfg.tls.cert} \
+      --key ${cfg.tls.key} \
+      --topic "$(parse-topic)" \
+      --id "$HOSTNAME"-sub
+    '';
+  };
 in
 {
   imports = [ inputs.villas-node.nixosModules.default ];
@@ -95,6 +122,8 @@ in
       mosquitto
       tpm2-tools
       villas-generate-gateway-config
+      listenMeasurements
+      parseTopic
     ];
 
     services.villas.node = {


### PR DESCRIPTION
Add `listen-measurements`, which wraps the `protobuf-subscriber` command from the SEGuRo platform repo to listen to gateway measurements on the mqtt broker.

The topic is parsed using `jq` from the VILLASnode config file created by the `villas-node.service`.