### PR TITLE
Add frame hook templating

### DIFF
--- a/config/gateway.json
+++ b/config/gateway.json
@@ -14,6 +14,8 @@
             "IG1_I3",
             "IG1_I1_Power"
           ],
+          "frameInterval": 30,
+          "frameUnit": "seconds",
           "uid": "mp1"
         }
       ],

--- a/nix/packages/villas-generate-gateway-config/seguro-gateway-config.nix
+++ b/nix/packages/villas-generate-gateway-config/seguro-gateway-config.nix
@@ -111,8 +111,8 @@ in
         {
           type = "frame";
           trigger = "timestamp";
-          interval = 10;
-          unit = "seconds";
+          interval = mp.frameInterval or 10;
+          unit = mp.frameUnit or "seconds";
         }
         {
           type = "digest";


### PR DESCRIPTION
Adds templating capabilities for `interval` and `unit` of the VILLASnode frame hook, by using the following keywords in the `gateway.json` on measurement point level.

```json
"frameInterval": 30,
"frameUnit": "seconds",
```
Example:
```json
{
  "devices": [
    {
      "description": "Measurement device in ACS laboratory - Unterverteilung 1",
      "name": "Janitza UMG 801",
      "points": [
        {
          "channels": [
            "U1",
            "U2",
            "U3",
            "IG1_I1",
            "IG1_I2",
            "IG1_I3",
            "IG1_I1_Power"
          ],
          "frameInterval": 30,
          "frameUnit": "seconds",
          "uid": "mp1"
        }
      ],
      "sending_rate": 1.0,
      "uid": "md1",
      "uri": "janitza-umg.acs-lab.eonerc.rwth-aachen.de"
    }
  ],
  "uid": "loc1"
}
```

Default values are set to `"frameInterval": 10` and `"frameUnit": "seconds"`. Hence, already existing configs will yield the same VILLASnode configuration as before.